### PR TITLE
Export "parser" module

### DIFF
--- a/rust_fsm_dsl/src/lib.rs
+++ b/rust_fsm_dsl/src/lib.rs
@@ -9,7 +9,7 @@ use quote::quote;
 use std::collections::HashSet;
 use syn::{parse_macro_input, Ident};
 
-mod parser;
+pub mod parser;
 
 /// The full information about a state transition. Used to unify the
 /// represantion of the simple and the compact forms.


### PR DESCRIPTION
Exporting the module makes programmatic introspection of state machines easier for various purposes, for example for rendering graphs of state machines, making unit tests verifying user-defined rules for transitions or detecting missing transitions etc.

Sample unit test:

```rust
use std::fs::read_to_string;

use syn::{Item, parse2};

use rust_fsm_dsl::parser::StateMachineDef;

#[test]
fn sm_transitions() {
    read_fsm("src/main.rs", "MainState")
        .transitions.into_iter()
        .for_each(|from| {
            let from_state = from.initial_state.to_string();
            from.transitions.into_iter().for_each(|transition_entry| {
                let to_state = transition_entry.final_state.to_string();
                // .. test transitions
            })
        });
}

fn read_fsm(file: &str, state_machine_name: &str) -> StateMachineDef {
    syn::parse_file(&read_to_string(file).expect("failed to read file"))
        .expect("Unable to parse file")
        .items.into_iter()
        .filter_map(|item|
            if let Item::Macro(item_macro) = item {
                let seg = &item_macro.mac.path.segments;
                if seg.len() == 1 && seg.first().unwrap().ident == "state_machine" {
                    Some(item_macro.mac.tokens)
                } else {
                    None
                }
            } else {
                None
            })
        .map(|ts| parse2::<StateMachineDef>(ts).expect("Failed to parse state machine definition"))
        .find(|fsm| fsm.name == state_machine_name)
        .expect("Did not find state machine definition with given name")
}
```