### PR TITLE
chore: add Debug/Clone derivations to StateMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning][semver].
 ## [Unreleased]
 ### Changed
 * Update documentation.
+### Added
+* Derive `Debug` and `Clone` for `StateMachine` struct
 
 ## [0.6.1] - 2022-12-24
 ### Changed

--- a/rust-fsm/src/lib.rs
+++ b/rust-fsm/src/lib.rs
@@ -159,6 +159,7 @@ pub trait StateMachineImpl {
 
 /// A convenience wrapper around the `StateMachine` trait that encapsulates the
 /// state and transition and output function calls.
+#[derive(Debug, Clone)]
 pub struct StateMachine<T: StateMachineImpl> {
     state: T::State,
 }


### PR DESCRIPTION
## Description
I have a struct that contains a state machine, and that struct needs `Debug` and `Clone` implemented for its members. This PR adds the default derivations of `Debug`/`Clone` to the `StateMachine` struct.

## Pull request checklist
<!-- PLEASE CHECK ALL THE BOXES BEFORE SUBMITTING YOUR PULL REQUEST -->

- [x] `package.version` fields in `Cargo.toml` files are unchanged.
- [x] `CHANGELOG.md` is updated.
- [x] `cargo-fmt` done.
- [x] `cargo-clippy` done.
- [x] `cargp-test` done.
- [x] The new changes are sufficiently tested.
