### PR TITLE
chore(deps): update aquamarine to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][keepachangelog], and this project
 adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
+### Changed
+* Updated  `aquamarine` from `0.5` to `0.6`.
 
 ## [0.7.0] - 2024-06-01
 ### Changed

--- a/rust-fsm/Cargo.toml
+++ b/rust-fsm/Cargo.toml
@@ -19,7 +19,7 @@ dsl = ["rust-fsm-dsl"]
 diagram = ["aquamarine", "rust-fsm-dsl/diagram"]
 
 [dependencies]
-aquamarine = { version = "0.5", optional = true }
+aquamarine = { version = "0.6", optional = true }
 rust-fsm-dsl = { path = "../rust-fsm-dsl", version = "0.7.0", optional = true }
 
 [profile.dev]


### PR DESCRIPTION
## Description
<!-- Put the description change and the rationale for it here -->
Updates the `aquamarine` dep from `0.5` to `0.6` (to get rid of proc-macro-error v1).

## Pull request checklist
<!-- PLEASE CHECK ALL THE BOXES BEFORE SUBMITTING YOUR PULL REQUEST -->

- [x] `package.version` fields in `Cargo.toml` files are unchanged.
- [x] `CHANGELOG.md` is updated.
- [x] `cargo-fmt` done.
- [x] `cargo-clippy` done.
Clippy complains on a thing unrelated to this PR: (will make a separate one)
```
warning: doc list item without indentation
   --> rust-fsm/src/lib.rs:126:1
    |
126 | `StateMachine<circuit_breaker::Impl>`.
    | ^
    |
    = help: if this is supposed to be its own paragraph, add a blank line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
    = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
    |
126 |   `StateMachine<circuit_breaker::Impl>`.
    | ++
```
- [x] `cargp-test` done.
- [x] The new changes are sufficiently tested.
