### PR TITLE
chore: fix clippy doc alignment

### DIFF
--- a/rust-fsm/src/lib.rs
+++ b/rust-fsm/src/lib.rs
@@ -123,7 +123,7 @@ The following entities are generated:
   `circuit_breaker::Output` that represent the state, the input alphabet and the
   output alphabet respectively.
 * Type alias `circuit_breaker::StateMachine` that expands to
-`StateMachine<circuit_breaker::Impl>`.
+  `StateMachine<circuit_breaker::Impl>`.
 
 Note that if there is no outputs in the specification, the output alphabet is an
 empty enum and due to technical limitations of many Rust attributes, no


### PR DESCRIPTION
## Description
<!-- Put the description change and the rationale for it here -->
Fixes the clippy warning I encountered in #14

## Pull request checklist
<!-- PLEASE CHECK ALL THE BOXES BEFORE SUBMITTING YOUR PULL REQUEST -->

- [x] `package.version` fields in `Cargo.toml` files are unchanged.
- [x] `CHANGELOG.md` is updated.
I think this is not needed.
- [x] `cargo-fmt` done.
- [x] `cargo-clippy` done.
- [x] `cargp-test` done.
- [x] The new changes are sufficiently tested.
