### PR TITLE
meta: fix cargo-test misspelling in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,5 @@
 - [ ] `CHANGELOG.md` is updated.
 - [ ] `cargo-fmt` done.
 - [ ] `cargo-clippy` done.
-- [ ] `cargp-test` done.
+- [ ] `cargo-test` done.
 - [ ] The new changes are sufficiently tested.


### PR DESCRIPTION
## Description
<!-- Put the description change and the rationale for it here -->
Whilst checking the list on doing #14, `cargp-test` should be `cargo-test`.

## Pull request checklist
<!-- PLEASE CHECK ALL THE BOXES BEFORE SUBMITTING YOUR PULL REQUEST -->

- [x] `package.version` fields in `Cargo.toml` files are unchanged.
- [x] `CHANGELOG.md` is updated.
I dont think this is needed.
- [x] `cargo-fmt` done.
- [x] `cargo-clippy` done.
- [x] `cargp-test` done.
**You can see this here as its not merged on master.**
- [x] The new changes are sufficiently tested.
