### PR TITLE
Guards and gen outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+
+- **Tuple variant support** for input types in DSL - inputs can now
+  carry data (e.g., `Coin(u32)` or `Input(u32, String, bool)` ).
+- **Guards** for conditional state transitions - transitions can include `if` clauses
+  with closures to _evaluate conditions based on input data_.
+- **Closure-based dynamic outputs** - outputs can be computed using closures
+  that process input data (e.g., `[|x, y| compute(x, y)]`).
+
+### Changed
+
+- Updated `syn` dependency to include `full` feature.
+- `prettyprint` is an optional dependency used with diagrams to improve
+  the visibility of the code of _guards_ and _closure-based outputs_
+
 ## [0.8.0] - 2025-07-21
 
 ### Changed
@@ -134,8 +149,7 @@ adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[Unreleased]:
-  https://github.com/eugene-babichenko/rust-fsm/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/eugene-babichenko/rust-fsm/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/eugene-babichenko/rust-fsm/compare/v0.8.0...v0.7.0
 [0.7.0]: https://github.com/eugene-babichenko/rust-fsm/compare/v0.7.0...v0.6.2
 [0.6.2]: https://github.com/eugene-babichenko/rust-fsm/compare/v0.6.2...v0.6.1

--- a/doc-example/Cargo.toml
+++ b/doc-example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rust-fsm = { path = "../rust-fsm", version = "0.9", features = ["diagram"] }
+rust-fsm = { path = "../rust-fsm", version = "0.9", features = ["diagram", "pretty-print"] }

--- a/doc-example/Cargo.toml
+++ b/doc-example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rust-fsm = { path = "../rust-fsm", version = "0.8", features = ["diagram"] }
+rust-fsm = { path = "../rust-fsm", version = "0.9", features = ["diagram"] }

--- a/doc-example/src/lib.rs
+++ b/doc-example/src/lib.rs
@@ -13,3 +13,28 @@ state_machine! {
         Unsuccessful => Open [SetupTimer]
     }
 }
+
+// Define a custom output type for the calculator
+#[derive(Debug, PartialEq)]
+pub enum CalcOutput {
+    Result(i32),
+    Clear,
+}
+
+state_machine! {
+    #[derive(Debug, PartialEq)]
+    #[state_machine(output(CalcOutput))]
+    /// A simple calculator state machine demonstrating arithmetic operations and error handling.
+    /// It uses Inputs carrying data, like _operands_, and closures to generate output.
+    pub calculator(Idle)
+
+    use super::CalcOutput;
+
+    Idle => {
+        Add(i32, i32) => Idle [|a: &i32, b: &i32| CalcOutput::Result(a + b)],
+        Multiply(i32, i32) => Idle [|x: &i32, y: &i32| CalcOutput::Result(x * y)],
+        Divide(i32, i32) if |_, y: &i32| *y == 0 => ErrDivByZero,
+        Divide(i32, i32) if |_, y: &i32| *y != 0 => Idle [ |x, y| CalcOutput::Result(x/y)],
+    },
+    ErrDivByZero(Reset) => Idle [Clear]
+}

--- a/rust-fsm-dsl/Cargo.toml
+++ b/rust-fsm-dsl/Cargo.toml
@@ -17,8 +17,10 @@ proc-macro = true
 
 [features]
 diagram = []
+pretty-print = ["prettyplease"]
 
 [dependencies]
 proc-macro2 = "1"
 syn = { version = "2", features = ["full"] }
 quote = "1"
+prettyplease = { version = "0.2", optional = true }

--- a/rust-fsm-dsl/Cargo.toml
+++ b/rust-fsm-dsl/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 license = "MIT"
 categories = ["data-structures", "rust-patterns"]
 keywords = ["fsm"]
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Yevhenii Babichenko"]
 edition = "2021"
 

--- a/rust-fsm-dsl/Cargo.toml
+++ b/rust-fsm-dsl/Cargo.toml
@@ -20,5 +20,5 @@ diagram = []
 
 [dependencies]
 proc-macro2 = "1"
-syn = "2"
+syn = { version = "2", features = ["full"] }
 quote = "1"

--- a/rust-fsm-dsl/src/diagram.rs
+++ b/rust-fsm-dsl/src/diagram.rs
@@ -1,0 +1,229 @@
+use crate::{parser, Transition};
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::collections::{BTreeMap, BTreeSet};
+use syn::{parse_quote, Expr, File, Ident, Item};
+
+static WRAP_FUNC_QED: &str = "Wrap function exists .qed";
+
+/// Sanitize and format guard expressions for use in Mermaid diagrams.
+///
+/// When the `pretty-print` feature is enabled, this uses prettyplease to format
+/// the expression in idiomatic Rust style. Otherwise, it uses basic sanitization
+/// to make the expression safe for Mermaid.
+pub fn sanitize_expr(expr: &Expr) -> String {
+    // Wrap the expression in a function that returns it, so prettyplease can format it
+    #[cfg(feature = "pretty-print")]
+    let (content, start, end) = {
+        let item: Item = parse_quote! {
+          fn __guard_expr() -> bool {
+            #expr
+          }
+        };
+        let file = File {
+            shebang: None,
+            attrs: Vec::new(),
+            items: vec![item],
+        };
+
+        let content = prettyplease::unparse(&file);
+        // Extract just the expression part from the function body
+        // The format will be: "fn __guard_expr() -> bool {\n    EXPR\n}\n"
+        let start = content.find('{').expect(WRAP_FUNC_QED);
+        let end = content.rfind('}').expect(WRAP_FUNC_QED);
+        (content, start, end)
+    };
+
+    #[cfg(feature = "pretty-print")]
+    let expr_str = content[start + 1..end].trim();
+
+    #[cfg(not(feature = "pretty-print"))]
+    let expr_str = quote! { #expr };
+
+    // Mermaid fixes
+    expr_str.replace(":", "")
+}
+
+pub fn build_diagram(initial_state: &Ident, transitions: &[Transition]) -> TokenStream {
+    // Track transitions per state to detect nested states
+    let mut transitions_per_state: BTreeMap<&Ident, Vec<&Transition>> = BTreeMap::new();
+
+    // Group transitions by initial state
+    for transition in transitions {
+        transitions_per_state
+            .entry(transition.initial_state)
+            .or_default()
+            .push(transition);
+    }
+
+    let mut diagram = format!(
+        "///```mermaid\n///stateDiagram-v2\n///    [*] --> {}\n",
+        initial_state
+    );
+
+    // Group transitions by (state, input_name) to detect guards
+    let mut transitions_by_state_input: BTreeMap<(&Ident, &Ident), Vec<&Transition>> =
+        BTreeMap::new();
+    for transition in transitions {
+        transitions_by_state_input
+            .entry((transition.initial_state, &transition.input_value.name))
+            .or_default()
+            .push(transition);
+    }
+
+    // First: identify choice states for inputs with guards
+    let mut choice_states_generated = BTreeSet::new();
+    for ((state, input_name), input_transitions) in &transitions_by_state_input {
+        // Check if this input has multiple transitions with guards
+        let has_guards = input_transitions.iter().any(|t| t.guard.is_some());
+        if has_guards && input_transitions.len() > 1 {
+            choice_states_generated.insert((*state, *input_name));
+        }
+    }
+
+    // Second: generate nested state definitions
+    for (state, state_transitions) in &transitions_per_state {
+        // Collect all self-referencing inputs (those that loop back to the same state)
+        let self_loop_inputs: BTreeSet<&Ident> = state_transitions
+            .iter()
+            .filter(|t| t.final_state == *state)
+            .map(|t| &t.input_value.name)
+            .collect();
+
+        // Check if this is a nested state (multiple self-loop inputs)
+        if self_loop_inputs.len() > 1 {
+            // Generate nested state representation
+            diagram.push_str(&format!("///state {} {{\n", state));
+
+            for input_name in &self_loop_inputs {
+                diagram.push_str(&format!("///    [*] --> {}\n", input_name));
+
+                // Check if this input has a choice state
+                let key = (*state, *input_name);
+                if choice_states_generated.contains(&key) {
+                    // Transition to choice state
+                    let choice_state_name = format!("{}_guard_{}", state, input_name);
+                    diagram.push_str(&format!(
+                        "///    {} --> {}\n",
+                        input_name, choice_state_name
+                    ));
+                } else {
+                    // Normal self-loop
+                    diagram.push_str(&format!("///{} --> [*]\n", input_name));
+                }
+            }
+
+            diagram.push_str("///}\n");
+        }
+    }
+
+    // Third: generate choice states for inputs with guards
+    for (state, input_name) in transitions_by_state_input.keys() {
+        let key = (*state, *input_name);
+        if choice_states_generated.contains(&key) {
+            let choice_state_name = format!("{}_guard_{}", state, input_name);
+            diagram.push_str(&format!("///state {} <<choice>>\n", choice_state_name));
+        }
+    }
+
+    // Second pass: generate transitions between states
+    for (state, state_transitions) in &transitions_per_state {
+        // Collect all self-referencing inputs
+        let self_loop_inputs: BTreeSet<&Ident> = state_transitions
+            .iter()
+            .filter(|t| t.final_state == *state)
+            .map(|t| &t.input_value.name)
+            .collect();
+
+        // Check if this is a nested state
+        let is_nested = self_loop_inputs.len() > 1;
+
+        // Group transitions by input to handle guards
+        let mut processed_inputs = BTreeSet::new();
+
+        // Generate transitions to other states
+        for transition in state_transitions.iter() {
+            let input_name = &transition.input_value.name;
+            let key = (*state, input_name);
+
+            // Skip if already processed this input (for guarded transitions)
+            if processed_inputs.contains(&key) {
+                continue;
+            }
+
+            // Check if this input has a choice state
+            if choice_states_generated.contains(&key) {
+                let choice_state_name = format!("{}_guard_{}", state, input_name);
+                let input_transitions = &transitions_by_state_input[&key];
+
+                // Check if this input is part of a self-loop (any transition returns to same state)
+                let has_self_loop = input_transitions.iter().any(|t| t.final_state == *state);
+
+                // Only generate transition from state to choice state if:
+                // - The state is NOT nested, OR
+                // - The input doesn't have ANY self-loop (all transitions go to different states)
+                // This avoids duplicating transitions that are already inside the nested state
+                if !is_nested || !has_self_loop {
+                    diagram.push_str(&format!("///    {} --> {}\n", state, choice_state_name));
+                }
+
+                // Generate transitions from choice state to final states
+                for guarded_transition in input_transitions {
+                    let guard_label = guarded_transition
+                        .guard
+                        .as_ref()
+                        .map(|guard| {
+                            let expr_str = sanitize_expr(&guard.expr);
+                            format!(":{expr_str}")
+                        })
+                        .unwrap_or_default();
+
+                    diagram.push_str(&format!(
+                        "///    {} --> {}{}\n",
+                        choice_state_name, guarded_transition.final_state, guard_label
+                    ));
+                }
+
+                processed_inputs.insert(key);
+            } else if transition.final_state != *state {
+                // Show the input name as the transition label for non-guarded transitions
+                diagram.push_str(&format!(
+                    "///    {} --> {}: {}\n",
+                    state, transition.final_state, input_name
+                ));
+                processed_inputs.insert(key);
+            } else if !is_nested {
+                // For single self-loops that aren't part of a nested state
+                let fields_expr = if !transition.input_value.fields.is_empty() {
+                    let fields = &transition.input_value.fields;
+                    format!(" ({})", quote! { #fields })
+                } else {
+                    String::new()
+                };
+                let output_str =
+                    if let Some(parser::OutputSpec::Constant(output_value)) = transition.output {
+                        format!(" [{output_value}]")
+                    } else {
+                        String::new()
+                    };
+                diagram.push_str(&format!(
+                    "///    {} --> {}: {}{}{}\n",
+                    state, transition.final_state, input_name, fields_expr, output_str
+                ));
+                processed_inputs.insert(key);
+            }
+        }
+    }
+
+    diagram.push_str("///```");
+    let diagram: TokenStream = diagram
+        .parse()
+        .inspect_err(|m_err| eprintln!("Mermaid diagram error: {m_err:?}\n\n{}", diagram))
+        .expect("Mermaid diagram is invalid");
+
+    quote! {
+        #[cfg_attr(doc, ::rust_fsm::aquamarine)]
+        #diagram
+    }
+}

--- a/rust-fsm-dsl/src/parser.rs
+++ b/rust-fsm-dsl/src/parser.rs
@@ -47,7 +47,7 @@ impl From<Output> for Option<OutputSpec> {
 /// Represents an input variant, which can be a simple identifier or a tuple variant
 pub struct InputVariant {
     pub name: Ident,
-    pub fields: Option<Punctuated<Type, Token![,]>>,
+    pub fields: Punctuated<Type, Token![,]>,
 }
 
 impl Parse for InputVariant {
@@ -57,9 +57,9 @@ impl Parse for InputVariant {
         let fields = if input.lookahead1().peek(Paren) {
             let content;
             parenthesized!(content in input);
-            Some(content.parse_terminated(Type::parse, Token![,])?)
+            content.parse_terminated(Type::parse, Token![,])?
         } else {
-            None
+            Punctuated::new()
         };
 
         Ok(Self { name, fields })

--- a/rust-fsm/Cargo.toml
+++ b/rust-fsm/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 license = "MIT"
 categories = ["data-structures", "rust-patterns"]
 keywords = ["fsm"]
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Yevhenii Babichenko"]
 edition = "2021"
 
@@ -20,7 +20,10 @@ diagram = ["aquamarine", "rust-fsm-dsl/diagram"]
 
 [dependencies]
 aquamarine = { version = "0.6", optional = true }
-rust-fsm-dsl = { path = "../rust-fsm-dsl", version = "0.8.0", optional = true }
+rust-fsm-dsl = { path = "../rust-fsm-dsl", version = "0.9.0", optional = true }
+
+[dev-dependencies]
+test-case = "3"
 
 [profile.dev]
 panic = "abort"

--- a/rust-fsm/Cargo.toml
+++ b/rust-fsm/Cargo.toml
@@ -17,6 +17,7 @@ default = ["std", "dsl"]
 std = []
 dsl = ["rust-fsm-dsl"]
 diagram = ["aquamarine", "rust-fsm-dsl/diagram"]
+pretty-print = ["rust-fsm-dsl/pretty-print"]
 
 [dependencies]
 aquamarine = { version = "0.6", optional = true }

--- a/rust-fsm/src/lib.rs
+++ b/rust-fsm/src/lib.rs
@@ -271,7 +271,7 @@ pub struct StateMachine<T: StateMachineImpl> {
     state: T::State,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// An error type that represents that the state transition is impossible given
 /// the current combination of state and input.
 pub struct TransitionImpossibleError;

--- a/rust-fsm/tests/circuit_breaker.rs
+++ b/rust-fsm/tests/circuit_breaker.rs
@@ -78,7 +78,7 @@ fn circuit_breaker() {
     // Set up a timer
     let machine_wait = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(5, 0));
+        std::thread::sleep(Duration::from_millis(500));
         let mut lock = machine_wait.lock().unwrap();
         let res = lock.consume(&CircuitBreakerInput::TimerTriggered).unwrap();
         assert_eq!(res, None);
@@ -88,7 +88,7 @@ fn circuit_breaker() {
     // Try to pass a request when the circuit breaker is still open
     let machine_try = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(1, 0));
+        std::thread::sleep(Duration::from_millis(100));
         let mut lock = machine_try.lock().unwrap();
         let res = lock.consume(&CircuitBreakerInput::Successful);
         assert!(matches!(res, Err(TransitionImpossibleError)));
@@ -96,7 +96,7 @@ fn circuit_breaker() {
     });
 
     // Test if the circit breaker was actually closed
-    std::thread::sleep(Duration::new(7, 0));
+    std::thread::sleep(Duration::from_millis(700));
     {
         let mut lock = machine.lock().unwrap();
         let res = lock.consume(&CircuitBreakerInput::Successful).unwrap();

--- a/rust-fsm/tests/circuit_breaker_dsl.rs
+++ b/rust-fsm/tests/circuit_breaker_dsl.rs
@@ -32,19 +32,19 @@ fn circit_breaker_dsl() {
     // Set up a timer
     let machine_wait = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(5, 0));
+        std::thread::sleep(Duration::from_millis(500));
         let mut lock = machine_wait.lock().unwrap();
         let res = lock
             .consume(&circuit_breaker::Input::TimerTriggered)
             .unwrap();
-        assert!(matches!(res, None));
+        assert!(res.is_none());
         assert!(matches!(lock.state(), &circuit_breaker::State::HalfOpen));
     });
 
     // Try to pass a request when the circuit breaker is still open
     let machine_try = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(1, 0));
+        std::thread::sleep(Duration::from_millis(100));
         let mut lock = machine_try.lock().unwrap();
         let res = lock.consume(&circuit_breaker::Input::Successful);
         assert!(matches!(res, Err(TransitionImpossibleError)));
@@ -52,11 +52,11 @@ fn circit_breaker_dsl() {
     });
 
     // Test if the circit breaker was actually closed
-    std::thread::sleep(Duration::new(7, 0));
+    std::thread::sleep(Duration::from_millis(700));
     {
         let mut lock = machine.lock().unwrap();
         let res = lock.consume(&circuit_breaker::Input::Successful).unwrap();
-        assert!(matches!(res, None));
+        assert!(res.is_none());
         assert!(matches!(lock.state(), &circuit_breaker::State::Closed));
     }
 }

--- a/rust-fsm/tests/circuit_breaker_dsl_custom_types.rs
+++ b/rust-fsm/tests/circuit_breaker_dsl_custom_types.rs
@@ -49,17 +49,17 @@ fn circit_breaker_dsl() {
     // Set up a timer
     let machine_wait = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(5, 0));
+        std::thread::sleep(Duration::from_millis(500));
         let mut lock = machine_wait.lock().unwrap();
         let res = lock.consume(&Input::TimerTriggered).unwrap();
-        assert!(matches!(res, None));
+        assert!(res.is_none());
         assert!(matches!(lock.state(), &State::HalfOpen));
     });
 
     // Try to pass a request when the circuit breaker is still open
     let machine_try = machine.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::new(1, 0));
+        std::thread::sleep(Duration::from_millis(100));
         let mut lock = machine_try.lock().unwrap();
         let res = lock.consume(&Input::Successful);
         assert!(matches!(res, Err(TransitionImpossibleError)));
@@ -67,11 +67,11 @@ fn circit_breaker_dsl() {
     });
 
     // Test if the circit breaker was actually closed
-    std::thread::sleep(Duration::new(7, 0));
+    std::thread::sleep(Duration::from_millis(700));
     {
         let mut lock = machine.lock().unwrap();
         let res = lock.consume(&Input::Successful).unwrap();
-        assert!(matches!(res, None));
+        assert!(res.is_none());
         assert!(matches!(lock.state(), &State::Closed));
     }
 }

--- a/rust-fsm/tests/guards_simple_example.rs
+++ b/rust-fsm/tests/guards_simple_example.rs
@@ -1,0 +1,37 @@
+/// Simple example of guards with tuple variants
+use rust_fsm::*;
+
+state_machine! {
+    #[derive(Debug, PartialEq)]
+    turnstile(Locked)
+
+    Locked => {
+        Coin(u32) if |amount: &u32| *amount >= 50 => Unlocked,
+        Coin(u32) if |amount: &u32| *amount < 50 => Locked [RefundInsufficient],
+        Push => Locked [AccessDenied]
+    },
+    Unlocked => {
+        Push => Locked,
+        Coin(u32) => Unlocked [AlreadyUnlocked]
+    }
+}
+
+#[test]
+fn test_simple_guard() {
+    let mut machine = turnstile::StateMachine::new();
+
+    // Insufficient coin
+    let res = machine.consume(&turnstile::Input::Coin(25));
+    assert_eq!(res, Ok(Some(turnstile::Output::RefundInsufficient)));
+    assert_eq!(machine.state(), &turnstile::State::Locked);
+
+    // Sufficient coin
+    let res = machine.consume(&turnstile::Input::Coin(50));
+    assert_eq!(machine.state(), &turnstile::State::Unlocked);
+    assert_eq!(res, Ok(None));
+
+    // Push through
+    let res = machine.consume(&turnstile::Input::Push);
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &turnstile::State::Locked);
+}

--- a/rust-fsm/tests/guards_with_tuple_variants.rs
+++ b/rust-fsm/tests/guards_with_tuple_variants.rs
@@ -1,0 +1,128 @@
+/// Test for guards with tuple variant inputs
+use rust_fsm::*;
+
+state_machine! {
+    #[derive(Debug, PartialEq, Eq)]
+    payment_system(Idle)
+
+    Idle => {
+        StartPayment(u32) if |amount: &u32| *amount >= 100 => Processing,
+        StartPayment(u32) if |amount: &u32| *amount < 100 => Idle [InsufficientAmount],
+        Cancel => Idle
+    },
+    Processing => {
+        Complete => Success,
+        Fail => Failed
+    },
+    Failed => {
+        Retry(u32) if |attempts: &u32| *attempts < 3 => Processing,
+        Retry(u32) if |attempts: &u32| *attempts >= 3 => Failed [MaxRetriesExceeded],
+        Cancel => Idle
+    },
+    Success(Reset) => Idle
+}
+
+#[test]
+fn test_guards_with_amount() {
+    let mut machine = payment_system::StateMachine::new();
+
+    // Test with insufficient amount (< 100)
+    let res = machine.consume(&payment_system::Input::StartPayment(50));
+    // Should stay in Idle state
+    assert_eq!(machine.state(), &payment_system::State::Idle);
+    // Should have output
+    if res != Ok(Some(payment_system::Output::InsufficientAmount)) {
+        panic!("Expected InsufficientAmount output");
+    }
+
+    // Test with sufficient amount (>= 100)
+    let res = machine.consume(&payment_system::Input::StartPayment(150));
+    assert!(res.is_ok());
+    // Should transition to Processing
+    assert_eq!(machine.state(), &payment_system::State::Processing);
+
+    // Complete the payment
+    let res = machine.consume(&payment_system::Input::Complete);
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &payment_system::State::Success);
+}
+
+#[test]
+fn test_guards_with_retry_logic() {
+    let mut machine = payment_system::StateMachine::new();
+
+    // Start with sufficient payment
+    machine
+        .consume(&payment_system::Input::StartPayment(200))
+        .unwrap();
+    assert_eq!(machine.state(), &payment_system::State::Processing);
+
+    // Fail the payment
+    machine.consume(&payment_system::Input::Fail).unwrap();
+    assert_eq!(machine.state(), &payment_system::State::Failed);
+
+    // Retry with attempts < 3 (should go back to Processing)
+    let res = machine.consume(&payment_system::Input::Retry(1));
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &payment_system::State::Processing);
+
+    // Fail again
+    machine.consume(&payment_system::Input::Fail).unwrap();
+    assert_eq!(machine.state(), &payment_system::State::Failed);
+
+    // Retry with attempts >= 3 (should stay in Failed)
+    let res = machine.consume(&payment_system::Input::Retry(3));
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &payment_system::State::Failed);
+    // Should have output
+    if res != Ok(Some(payment_system::Output::MaxRetriesExceeded)) {
+        panic!("Expected MaxRetriesExceeded output");
+    }
+}
+
+#[test]
+fn test_guards_multiple_fields() {
+    state_machine! {
+        #[derive(Debug, PartialEq)]
+        user_system(Pending)
+
+        Pending => {
+            UserData(String, u32, bool) if |_name: &String, age: &u32, premium: &bool| *age >= 18 && *premium => VipUser,
+            UserData(String, u32, bool) if |_name: &String, age: &u32, _premium: &bool| *age >= 18 => RegularUser,
+            UserData(String, u32, bool) if |_name: &String, age: &u32, _premium: &bool| *age < 18 => MinorUser [ParentalConsentRequired],
+        },
+        VipUser(Downgrade) => RegularUser,
+        RegularUser(Upgrade) => VipUser,
+        MinorUser(Approve) => RegularUser
+    }
+
+    let mut machine = user_system::StateMachine::new();
+
+    // Test VIP user (age >= 18 and premium)
+    let res = machine.consume(&user_system::Input::UserData("Alice".to_string(), 25, true));
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &user_system::State::VipUser);
+
+    // Reset
+    let mut machine = user_system::StateMachine::new();
+
+    // Test regular user (age >= 18 but not premium)
+    let res = machine.consume(&user_system::Input::UserData("Bob".to_string(), 20, false));
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &user_system::State::RegularUser);
+
+    // Reset
+    let mut machine = user_system::StateMachine::new();
+
+    // Test minor user (age < 18)
+    let res = machine.consume(&user_system::Input::UserData(
+        "Charlie".to_string(),
+        16,
+        false,
+    ));
+    assert!(res.is_ok());
+    assert_eq!(machine.state(), &user_system::State::MinorUser);
+    if res != Ok(Some(user_system::Output::ParentalConsentRequired)) {
+        panic!("Expected ParentalConsentRequired output");
+    }
+}

--- a/rust-fsm/tests/output_with_call.rs
+++ b/rust-fsm/tests/output_with_call.rs
@@ -54,11 +54,11 @@ state_machine! {
     #[state_machine(output(StringOutput))]
     string_processor(Ready)
 
-    use crate::StringOutput;
+    use super::StringOutput;
 
     Ready => {
         Process(String) => Ready [|s: &String| StringOutput::Length(s.len())],
-        Concat(String, String) => Ready [|a: &String, b: &String| StringOutput::Combined(format!("{}{}", a, b))],
+        Concat(String, String) => Ready [ |a: &str, b: &str| StringOutput::Combined(format!("{a}{b}"))],
         Clear => Ready
     }
 }
@@ -97,7 +97,7 @@ state_machine! {
     #[state_machine(output(ValidatorOutput))]
     validator(Waiting)
 
-    use crate::ValidatorOutput;
+    use super::ValidatorOutput;
 
     Waiting => {
         CheckRange(i32, i32, i32) => Waiting [|value: &i32, start: &i32, end: &i32| {

--- a/rust-fsm/tests/output_with_call.rs
+++ b/rust-fsm/tests/output_with_call.rs
@@ -1,0 +1,127 @@
+/// Test for output with call closures
+use rust_fsm::*;
+
+use std::ops::Range;
+use test_case::test_case;
+
+// Define a custom output type for the calculator
+#[derive(Debug, PartialEq)]
+pub enum CalcOutput {
+    Result(i32),
+}
+
+state_machine! {
+    #[derive(Debug, PartialEq)]
+    #[state_machine(output(CalcOutput))]
+    calculator(Idle)
+
+    use super::CalcOutput;
+
+    Idle => {
+        Add(i32, i32) => Idle [|a: &i32, b: &i32| CalcOutput::Result(a + b)],
+        Multiply(i32, i32) => Idle [|x: &i32, y: &i32| CalcOutput::Result(x * y)],
+        Reset => Idle
+    }
+}
+
+#[test]
+fn test_calculator_with_closures() {
+    let mut machine = calculator::StateMachine::new();
+
+    // Test addition
+    let result = machine.consume(&calculator::Input::Add(5, 3)).unwrap();
+    assert_eq!(result, Some(CalcOutput::Result(8)));
+    assert_eq!(machine.state(), &calculator::State::Idle);
+
+    // Test multiplication
+    let result = machine.consume(&calculator::Input::Multiply(4, 7)).unwrap();
+    assert_eq!(result, Some(CalcOutput::Result(28)));
+    assert_eq!(machine.state(), &calculator::State::Idle);
+
+    // Test reset (no output)
+    let result = machine.consume(&calculator::Input::Reset).unwrap();
+    assert!(result.is_none());
+}
+
+#[derive(Debug, PartialEq)]
+pub enum StringOutput {
+    Length(usize),
+    Combined(String),
+}
+
+state_machine! {
+    #[derive(Debug)]
+    #[state_machine(output(StringOutput))]
+    string_processor(Ready)
+
+    use crate::StringOutput;
+
+    Ready => {
+        Process(String) => Ready [|s: &String| StringOutput::Length(s.len())],
+        Concat(String, String) => Ready [|a: &String, b: &String| StringOutput::Combined(format!("{}{}", a, b))],
+        Clear => Ready
+    }
+}
+
+#[test]
+fn test_string_processor_with_closures() {
+    let mut machine = string_processor::StateMachine::new();
+
+    // Test string length
+    let result = machine
+        .consume(&string_processor::Input::Process("hello".to_string()))
+        .unwrap();
+    assert_eq!(result, Some(StringOutput::Length(5)));
+
+    // Test concatenation
+    let result = machine
+        .consume(&string_processor::Input::Concat(
+            "Hello".to_string(),
+            "World".to_string(),
+        ))
+        .unwrap();
+    assert_eq!(
+        result,
+        Some(StringOutput::Combined("HelloWorld".to_string()))
+    );
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ValidatorOutput {
+    Valid,
+    Invalid,
+}
+
+state_machine! {
+    #[derive(Debug)]
+    #[state_machine(output(ValidatorOutput))]
+    validator(Waiting)
+
+    use crate::ValidatorOutput;
+
+    Waiting => {
+        CheckRange(i32, i32, i32) => Waiting [|value: &i32, start: &i32, end: &i32| {
+            if value >= start && value < end {
+                ValidatorOutput::Valid
+            } else {
+                ValidatorOutput::Invalid
+            }
+        }],
+        Reset => Waiting
+    }
+}
+
+#[test_case( 50, 0..100 => ValidatorOutput::Valid)]
+#[test_case( 150, 0..100 => ValidatorOutput::Invalid)]
+#[test_case( -10, 0..100 => ValidatorOutput::Invalid)]
+#[test_case( 0, 0..100 => ValidatorOutput::Valid)]
+#[test_case( 99, 0..100 => ValidatorOutput::Valid)]
+#[test_case( 100, 0..100 => ValidatorOutput::Invalid)]
+fn test_closure_captures_complex_logic(value: i32, range: Range<i32>) -> ValidatorOutput {
+    let mut machine = validator::StateMachine::new();
+
+    machine
+        .consume(&validator::Input::CheckRange(value, range.start, range.end))
+        .unwrap()
+        .unwrap()
+}

--- a/rust-fsm/tests/tuple_variant_input.rs
+++ b/rust-fsm/tests/tuple_variant_input.rs
@@ -1,0 +1,98 @@
+/// Test for tuple variant input support in the state_machine! macro
+use rust_fsm::*;
+
+state_machine! {
+    turnstile(Locked)
+
+    Locked => {
+        Coin(u32) => Unlocked,
+        Push => Locked
+    },
+    Unlocked(Push) => Locked
+}
+
+state_machine! {
+    complex_machine(Start)
+
+    Start => {
+        Data(String, u32, bool) => Processing,
+        Skip => End
+    },
+    Processing => {
+        Complete => End,
+        Retry(u32) => Processing
+    },
+    End(Reset) => Start
+}
+
+#[test]
+fn tuple_variant_input() {
+    let mut machine = turnstile::StateMachine::new();
+
+    // Initial state should be Locked
+    assert!(matches!(machine.state(), &turnstile::State::Locked));
+
+    // Insert coin (tuple variant with u32 value)
+    let res = machine.consume(&turnstile::Input::Coin(100));
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &turnstile::State::Unlocked));
+
+    // Push through (unit variant)
+    let res = machine.consume(&turnstile::Input::Push);
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &turnstile::State::Locked));
+
+    // Try to push when locked
+    let res = machine.consume(&turnstile::Input::Push);
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &turnstile::State::Locked));
+
+    // Insert different coin amount
+    let res = machine.consume(&turnstile::Input::Coin(50));
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &turnstile::State::Unlocked));
+}
+
+#[test]
+fn tuple_variant_pattern_matching() {
+    // Test that we can pattern match on tuple variants
+    let coin_input = turnstile::Input::Coin(100);
+
+    match coin_input {
+        turnstile::Input::Coin(amount) => {
+            assert_eq!(amount, 100);
+        }
+        _ => panic!("Expected Coin variant"),
+    }
+}
+
+#[test]
+fn complex_tuple_variants() {
+    let mut machine = complex_machine::StateMachine::new();
+
+    // Test multi-field tuple variant
+    let res = machine.consume(&complex_machine::Input::Data("test".to_string(), 42, true));
+    assert!(res.is_ok());
+    assert!(matches!(
+        machine.state(),
+        &complex_machine::State::Processing
+    ));
+
+    // Test single-field tuple variant
+    let res = machine.consume(&complex_machine::Input::Retry(3));
+    assert!(res.is_ok());
+    assert!(matches!(
+        machine.state(),
+        &complex_machine::State::Processing
+    ));
+
+    // Test unit variant
+    let res = machine.consume(&complex_machine::Input::Complete);
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &complex_machine::State::End));
+
+    // Test reset
+    let res = machine.consume(&complex_machine::Input::Reset);
+    assert!(res.is_ok());
+    assert!(matches!(machine.state(), &complex_machine::State::Start));
+}


### PR DESCRIPTION
## Description
- Add **Guards** and Inputs with tuple variant support, so you can make a transition if a condition is true.
In the following example, `Locked` can move to `Unlocked` if the amount of `Coin` is equal or greater than 50:

```Rust
state_machine! {
    #[derive(Debug, PartialEq)]
    turnstile(Locked)

    Locked => {
        Coin(u32) if |amount: &u32| *amount >= 50 => Unlocked,
        Coin(u32) if |amount: &u32| *amount < 50 => Locked [RefundInsufficient],
        Push => Locked [AccessDenied]
    },
    Unlocked => {
        Push => Locked,
        Coin(u32) => Unlocked [AlreadyUnlocked]
    }
}
```

- Add **Closure-based outputs**, so outputs can be generated based on inputs.

```Rust
pub enum ValidatorOutput {
    Valid,
    Invalid,
}

state_machine! {
    #[derive(Debug)]
    #[state_machine(output(ValidatorOutput))]
    validator(Waiting)

    use super::ValidatorOutput;

    Waiting => {
        CheckRange(i32, i32, i32) => Waiting [|value: &i32, start: &i32, end: &i32| {
            if value >= start && value < end {
                ValidatorOutput::Valid
            } else {
                ValidatorOutput::Invalid
            }
        }],
        Reset => Waiting
    }
}
```


## Pull request checklist
<!-- PLEASE CHECK ALL THE BOXES BEFORE SUBMITTING YOUR PULL REQUEST -->

- [ ] `package.version` fields in `Cargo.toml` files are unchanged.
- [x] `CHANGELOG.md` is updated.
- [x] `cargo-fmt` done.
- [x] `cargo-clippy` done.
- [x] `cargo-test` done.
- [x] The new changes are sufficiently tested. **NOTE**: Working on it
